### PR TITLE
pass 'numbers' not 'arr'

### DIFF
--- a/week-2/J-array-get-set/exercise.js
+++ b/week-2/J-array-get-set/exercise.js
@@ -18,7 +18,7 @@ function last(arr) {
 var numbers = [1, 2, 3];
 var names = ["Irina", "Ashleigh", "Mozafar"];
 
-console.log(first(arr));
+console.log(first(numbers));
 console.log(last(names));
 
 /* 


### PR DESCRIPTION
In reference to issue #21  "I-array-properties (2)" in original repo, the array name should be 'numbers' not 'arr'